### PR TITLE
Add player_manager.GetTable() and PLAYER:Destroy()

### DIFF
--- a/garrysmod/lua/includes/modules/player_manager.lua
+++ b/garrysmod/lua/includes/modules/player_manager.lua
@@ -301,15 +301,7 @@ AddValidHands( "dod_american", "models/weapons/c_arms_dod.mdl",		1,		"10000000" 
 
 local Type = {}
 
-function GetTable()
-	local tbl = {}
-	
-	for k, v in pairs( Type ) do
-		tbl[ k ] = v
-	end
-	
-	return tbl
-end
+function GetTable() return Type end
 
 function RegisterClass( name, table, base )
 

--- a/garrysmod/lua/includes/modules/player_manager.lua
+++ b/garrysmod/lua/includes/modules/player_manager.lua
@@ -301,6 +301,16 @@ AddValidHands( "dod_american", "models/weapons/c_arms_dod.mdl",		1,		"10000000" 
 
 local Type = {}
 
+function GetTable()
+	local tbl = {}
+	
+	for k, v in pairs( Type ) do
+		tbl[ k ] = v
+	end
+	
+	return tbl
+end
+
 function RegisterClass( name, table, base )
 
 	Type[ name ] = table;
@@ -361,8 +371,11 @@ local function LookupPlayerClass( ply )
 	--
 	-- Check the cache
 	--
-	local method = ply.m_CurrentPlayerClass;
-	if ( method && method.Player == ply && method.ClassID == id && method.Func ) then return method end
+	local method = ply.m_CurrentPlayerClass
+	if ( method && method.Player == ply ) then
+		if ( method.ClassID == id ) then return method end -- current class is still good, behave normally
+		if ( method.Destroy ) then method:Destroy() end -- the class id changed, destroy the old class
+	end
 
 	--
 	-- No class, lets create one
@@ -379,7 +392,6 @@ local function LookupPlayerClass( ply )
 	local method = {}
 		method.Player	= ply
 		method.ClassID	= id
-		method.Func		= function() end
 
 	setmetatable( method, { __index = t } )
 

--- a/garrysmod/lua/includes/modules/player_manager.lua
+++ b/garrysmod/lua/includes/modules/player_manager.lua
@@ -301,7 +301,17 @@ AddValidHands( "dod_american", "models/weapons/c_arms_dod.mdl",		1,		"10000000" 
 
 local Type = {}
 
-function GetTable() return Type end
+function GetTable()
+
+	local tbl = {}
+	
+	for k, v in pairs( Type ) do
+		tbl[ k ] = v
+	end
+	
+	return tbl
+
+end
 
 function RegisterClass( name, table, base )
 
@@ -365,7 +375,7 @@ local function LookupPlayerClass( ply )
 	--
 	local method = ply.m_CurrentPlayerClass
 	if ( method && method.Player == ply ) then
-		if ( method.ClassID == id ) then return method end -- current class is still good, behave normally
+		if ( method.ClassID == id && method.Func ) then return method end -- current class is still good, behave normally
 		if ( method.Destroy ) then method:Destroy() end -- the class id changed, destroy the old class
 	end
 
@@ -384,6 +394,7 @@ local function LookupPlayerClass( ply )
 	local method = {}
 		method.Player	= ply
 		method.ClassID	= id
+		method.Func	= function() end
 
 	setmetatable( method, { __index = t } )
 


### PR DESCRIPTION
Getting the table of registered player classes is a pain and PLAYER:Destroy() would be useful for removing things that aren't garbage collected, such as client-side props and projected textures. Also, method.Func looks useless, might want to remove it.